### PR TITLE
Validate staging structure

### DIFF
--- a/bin/ldr_stageContents.py
+++ b/bin/ldr_stageContents.py
@@ -154,7 +154,7 @@ def main():
             destinationDataFolder=join(destinationDataRoot,prefix)
             assert(isdir(destinationDataFolder))
 
-        stagingDebugLog = FileHandler(join(destinationAdminFolder,'log.presform.txt'))
+        stagingDebugLog = FileHandler(join(destinationAdminFolder,'log.txt'))
         stagingDebugLog.setFormatter(log_format)
         stagingDebugLog.setLevel('DEBUG')
         logger.addHandler(stagingDebugLog)

--- a/bin/ldr_staging_validate.py
+++ b/bin/ldr_staging_validate.py
@@ -67,7 +67,8 @@ def main():
     )
     ch = StreamHandler()
     ch.setFormatter(log_format)
-    logger.setLevel(args.log_level)
+    ch.setLevel('INFO')
+    logger.setLevel('DEBUG')
     if args.log_loc:
         fh = FileHandler(args.log_loc)
         fh.setFormatter(log_format)
@@ -115,7 +116,7 @@ def main():
             loggern.warn('Accession Number: '+accNo)
 
         logger.info("Checking the accession number directory.")
-        if not isdir(eadPath):
+        if not isdir(accNoPath):
             logger.warn("The accession number isn't a directory!")
             return 1
         if len(listdir(accNoPath)) != 2 or 'data' not in listdir(accNoPath) or 'admin' not in listdir(accNoPath):
@@ -133,7 +134,12 @@ def main():
         if not isdir(dataPath):
             logger.warn("The data path isn't a directory!")
             return 1
-        dataFolderList=listdir(dataPath)
+        dataFolderList=[x for x in listdir(dataPath) if isdir(join(dataPath,x))]
+        if dataFolderList != listdir(dataPath):
+            logger.warn("The following are in the data directory but aren't directories:")
+            for entry in listdir(dataPath):
+                if entry not in dataFolderList:
+                    logger.warn(entry)
         prefixList=[]
         for folder in dataFolderList:
             if not isdir(join(dataPath,folder)):
@@ -162,7 +168,12 @@ def main():
 
         logger.info("Checking admin directory.")
         adminPath=join(accNoPath,"admin")
-        adminFolderList=listdir(adminPath)
+        adminFolderList=[x for x in listdir(adminPath) if isdir(join(adminPath,x))]
+        if adminFolderList != listdir(adminPath):
+            logger.warn("The following are in the admin directory but aren't directories:")
+            for entry in listdir(adminPath):
+                if entry not in adminFolderList:
+                    logger.warn(entry)
         adminPrefixList=[]
         for folder in adminFolderList:
             if not isdir(join(adminPath,folder)):
@@ -209,7 +220,7 @@ def main():
                 logger.warn(join(dataPath,folder)+" appears in data but not in admin.")
 
 
-
+        logger.info('Run complete')
         return 0
     except KeyboardInterrupt:
         logger.error("Program aborted manually")

--- a/bin/ldr_staging_validate.py
+++ b/bin/ldr_staging_validate.py
@@ -123,11 +123,10 @@ def main():
                 logger.warn("There appear to be too many or too few directories in your accession number directory.")
             if 'data' not in listdir(accNoPath):
                 logger.warn("There doesn't appear to be a data directory in your accession number directory.")
-                return 1
             if 'admin' not in listdir(accNoPath):
                 logger.warn("There doesn't appear to be an admin directory in your accession number directory.")
-                return 1
             logger.warn('Accession number directory contents: '+",".join(listdir(accNoPath)))
+            return 1
 
         logger.info("Checking data directory.")
         dataPath=join(accNoPath,"data")
@@ -139,6 +138,7 @@ def main():
         for folder in dataFolderList:
             if not isdir(join(dataPath,folder)):
                 logger.warn(join(dataPath,folder)+" isn't a directory!")
+                return 1
             prefix=re_compile('^[a-zA-Z_-]*').match(folder).group(0)
             try:
                 prefix=re_compile('^[a-zA-Z_-]*').match(folder).group(1)

--- a/bin/ldr_staging_validate.py
+++ b/bin/ldr_staging_validate.py
@@ -168,11 +168,16 @@ def main():
 
         logger.info("Checking admin directory.")
         adminPath=join(accNoPath,"admin")
+        topLevelAdminFiles=['fileConversions.txt','record.json']
+        for entry in topLevelAdminFiles:
+            if entry not in listdir(adminPath):
+                logger.warn(entry+" is missing from the admin folder!")
+
         adminFolderList=[x for x in listdir(adminPath) if isdir(join(adminPath,x))]
-        if adminFolderList != listdir(adminPath):
+        if adminFolderList != [x for x in listdir(adminPath) if x not in topLevelAdminFiles]:
             logger.warn("The following are in the admin directory but aren't directories:")
             for entry in listdir(adminPath):
-                if entry not in adminFolderList:
+                if entry not in adminFolderList and entry not in topLevelAdminFiles:
                     logger.warn(entry)
         adminPrefixList=[]
         for folder in adminFolderList:

--- a/bin/ldr_validateStagingStructure.py
+++ b/bin/ldr_validateStagingStructure.py
@@ -86,7 +86,8 @@ def main():
         logger.info("Checking ARK directory")
         if len(listdir(args.item)) > 1:
             logger.warn("It appears as though there is more than one thing in the ARK directory!")
-            logger.warn("Directory contents: "+listdir(args.item))
+            logger.warn("Directory contents: "+",".join(listdir(args.item)))
+            return 1
 
         logger.info("Checking the EAD ID.")
         eadSuffix=listdir(args.item)[0]
@@ -98,7 +99,8 @@ def main():
         logger.info("Checking the EAD ID Directory.")
         if len(listdir(eadPath)) > 1:
             logger.warn("It appears as though there is more than one thing in your EAD directory!")
-            logger.warn("Directory contents: "+listdir(eadPath))
+            logger.warn("Directory contents: "+",".join(listdir(eadPath)))
+            return 1
 
         accNo=listdir(eadPath)[0]
         accNoPath=join(eadPath,accNo)
@@ -115,9 +117,11 @@ def main():
                 logger.warn("There appear to be too many or too few directories in your accession number directory.")
             if 'data' not in listdir(accNoPath):
                 logger.warn("There doesn't appear to be a data directory in your accession number directory.")
+                return 1
             if 'admin' not in listdir(accNoPath):
                 logger.warn("There doesn't appear to be an admin directory in your accession number directory.")
-            logger.warn('Directory contents: '+listdir(accNoPath))
+                return 1
+            logger.warn('Accession number directory contents: '+",".join(listdir(accNoPath)))
 
         logger.info("Checking data directory.")
         dataPath=join(accNoPath,"data")
@@ -157,6 +161,7 @@ def main():
             except IndexError:
                 pass
             adminPrefixList.append(prefix)
+        adminPrefixList=set(adminPrefixList)
         for prefix in adminPrefixList:
             if prefix not in prefixList:
                 logger.warn("The '"+prefix+"' prefix appears in the admin directory but not the data directory!")
@@ -164,7 +169,7 @@ def main():
             if prefix not in adminPrefixList:
                 logger.warn("The '"+prefix+"'prefix appears in the data directory but not the admin directory!")
         for prefix in adminPrefixList:
-            prefixSet=[directory for directory in listdir(dataPath) if re_compile('^'+prefix).match(directory)]
+            prefixSet=[directory for directory in listdir(adminPath) if re_compile('^'+prefix).match(directory)]
             nums=[]
             for folder in prefixSet:
                 num=folder.lstrip(prefix)

--- a/bin/ldr_validateStagingStructure.py
+++ b/bin/ldr_validateStagingStructure.py
@@ -1,0 +1,107 @@
+
+__author__ = "Brian Balsamo"
+__copyright__ = "Copyright 2015, The University of Chicago"
+__version__ = "0.0.1"
+__maintainer__ = "Brian Balsamo"
+__email__ = "Balsamo@uchicago.edu"
+__status__ = "Development"
+
+"""
+A small utility for validating staging structures after they have been populated, alerting the user to any potential errors
+"""
+
+from argparse import ArgumentParser
+from logging import DEBUG, FileHandler, Formatter, getLogger, \
+    INFO, StreamHandler
+from os import _exit,listdir
+from os.path import relpath,join,isdir,isfile
+from re import compile as re_compile
+
+from uchicagoldr.batch import Batch
+from uchicagoldr.item import Item
+
+def main():
+    # start of parser boilerplate
+    parser = ArgumentParser(description="A utility for validating staging structures after they have been populated, meant to alert the user to any potential errors",
+                            epilog="Copyright University of Chicago; " + \
+                            "written by "+__author__ + \
+                            " "+__email__)
+
+    parser.add_argument("-v", help="See the version of this program",
+                        action="version", version=__version__)
+    # let the user decide the verbosity level of logging statements
+    # -b sets it to INFO so warnings, errors and generic informative statements
+    # will be logged
+    parser.add_argument( \
+                         '-b','-verbose',help="set verbose logging",
+                         action='store_const',dest='log_level',
+                         const=INFO,default='INFO' \
+    )
+    # -d is debugging so anything you want to use a debugger gets logged if you
+    # use this level
+    parser.add_argument( \
+                         '-d','--debugging',help="set debugging logging",
+                         action='store_const',dest='log_level',
+                         const=DEBUG,default='INFO' \
+    )
+    # optionally save the log to a file. set a location or use the default constant
+    parser.add_argument( \
+                         '-l','--log_loc',help="save logging to a file",
+                         dest="log_loc",
+                         \
+    )
+    parser.add_argument("item", help="Enter a noid for an accession or a " + \
+                        "directory path that you need to validate against" + \
+                        " a type of controlled collection"
+    )
+    parser.add_argument("root",help="Enter the root of the directory path",
+                        action="store"
+    )
+    args = parser.parse_args()
+    log_format = Formatter( \
+                            "[%(levelname)s] %(asctime)s  " + \
+                            "= %(message)s",
+                            datefmt="%Y-%m-%dT%H:%M:%S" \
+    )
+    global logger
+    logger = getLogger( \
+                        "lib.uchicago.repository.logger" \
+    )
+    ch = StreamHandler()
+    ch.setFormatter(log_format)
+    logger.setLevel(args.log_level)
+    if args.log_loc:
+        fh = FileHandler(args.log_loc)
+        fh.setFormatter(log_format)
+        logger.addHandler(fh)
+    logger.addHandler(ch)
+    #BEGIN MAIN HERE - EXAMPLE BELOW
+    try:
+#        pathNoRoot=relpath(args.item,start=args.root)
+        logger.info("Checking the ARK.")
+        ark=relpath(args.item,start=args.root)
+        if not re_compile('\w{13}').match(ark):
+            logger.warn(ark+" doesn't look like a valid ARK!"
+
+        logger.info("Checking ARK directory")
+        if len(listdir(args.item)) > 1:
+            logger.warn("It appears as though there is more than one thing in the ARK directory!")
+            logger.warn("Directory contents: "+listdir(args.item))
+
+        eadSuffix=listdir(args.item)[1]
+        eadPath=join(args.item,eadSuffix)
+        if eadSuffix != eadSuffix.upper():
+            logger.warn("Your EAD suffix isn't capitalized!")
+            logger.warn("EAD Suffix: "+eadSuffix)
+
+        if len(listdir(eadPath)) > 1:
+            logger.warn("It appears as though there is more than one thing in your EAD directory!")
+
+
+        return 0
+    except KeyboardInterrupt:
+        logger.error("Program aborted manually")
+        return 131
+
+if __name__ == "__main__":
+    _exit(main())

--- a/bin/ldr_validateStagingStructure.py
+++ b/bin/ldr_validateStagingStructure.py
@@ -35,7 +35,7 @@ def main():
     parser.add_argument( \
                          '-b','-verbose',help="set verbose logging",
                          action='store_const',dest='log_level',
-                         const=INFO,default='INFO' \
+                         const=INFO,default='WARN' \
     )
     # -d is debugging so anything you want to use a debugger gets logged if you
     # use this level

--- a/bin/ldr_validateStagingStructure.py
+++ b/bin/ldr_validateStagingStructure.py
@@ -80,22 +80,41 @@ def main():
 #        pathNoRoot=relpath(args.item,start=args.root)
         logger.info("Checking the ARK.")
         ark=relpath(args.item,start=args.root)
-        if not re_compile('\w{13}').match(ark):
-            logger.warn(ark+" doesn't look like a valid ARK!"
+        print(ark)
+        print(re_compile('\w{13}').match(ark))
+        if not re_compile('^\w{13}$').match(ark):
+            logger.warn(ark+" doesn't look like a valid ARK!")
+        else:
+            print("ark looks good")
 
         logger.info("Checking ARK directory")
         if len(listdir(args.item)) > 1:
             logger.warn("It appears as though there is more than one thing in the ARK directory!")
             logger.warn("Directory contents: "+listdir(args.item))
 
-        eadSuffix=listdir(args.item)[1]
+        logger.info("Checking the EAD ID.")
+        eadSuffix=listdir(args.item)[0]
         eadPath=join(args.item,eadSuffix)
         if eadSuffix != eadSuffix.upper():
             logger.warn("Your EAD suffix isn't capitalized!")
             logger.warn("EAD Suffix: "+eadSuffix)
 
+        logger.info("Checking the EAD ID Directory.")
         if len(listdir(eadPath)) > 1:
             logger.warn("It appears as though there is more than one thing in your EAD directory!")
+            logger.warn("Directory contents: "+listdir(eadPath))
+
+        accNo=listdir(eadPath)[0]
+        accNoPath=join(eadPath,accNo)
+
+        logger.info("Checking the accession number")
+        pattern=re_compile('^\d{4}-\d{3}$')
+        if not pattern.match(accNo):
+            logger.warn('Your accession number doesn\'t appear to be valid.')
+            loggern.warn('Accession Number: '+accNo)
+
+
+
 
 
         return 0


### PR DESCRIPTION
Wrote a script which validates several aspects of the staging structure as built in the new staging scripts.

1) The general layout is...
ark/ead/acc #/(data||admin)/prefix+number
2) The ark is 13 characters long
3) The EAD suffix is all uppercase
4) The accession number matches ####-###
5) The accession number directory contains exactly two directories, data and admin
6) Prefixes have no numbers in the middle of them
7) Folders in any given prefix are in a solid range (eg 1,2,3, not 1,3,4)
8) There is an admin folder which contains fixityFromOrigin,fixityInStaging,log, and rsyncFromOrigin .txt files for each data folder.
