### PR TITLE
Logging and boilerplate

### DIFF
--- a/bin/ldr_logging_test.py
+++ b/bin/ldr_logging_test.py
@@ -23,9 +23,11 @@ from os.path import split,exists
 ### Local package imports begin ###
 from uchicagoldrLogging.loggers import MasterLogger
 from uchicagoldrLogging.handlers import DefaultTermHandler,DebugTermHandler,DefaultFileHandler,DebugFileHandler,DefaultTermHandlerAtLevel,DefaultFileHandlerAtLevel
+from uchicagoldrLogging.filters import UserAndIPFilter
 
 from uchicagoldr.batch import Batch
 from uchicagoldr.item import Item
+
 ### Local package imports end ###
 
 
@@ -42,8 +44,10 @@ def main():
     ### Application specific log instantation begins ###
     global logger
     logger=masterLog.getChild(__name__)
+    f=UserAndIPFilter()
     termHandler=DefaultTermHandler()
     logger.addHandler(termHandler)
+    logger.addFilter(f)
     ### Application specific log instantation ends ###
 
     ### Parser instantiation begins ###
@@ -117,15 +121,14 @@ def main():
         logger.warn('Warn Message')
         logger.error('Error Message')
         logger.critical('Critical Message')
-            
+        ### End module code ###
         logger.info("ENDS: COMPLETE")
         return 0
-        ### End module code ###
     except KeyboardInterrupt:
         logger.error("ENDS: Program aborted manually")
         return 131
     except Exception as e:
-        logger.critical("ENDS: Exception ("+e+")")
+        logger.critical("ENDS: Exception ("+str(e)+")")
         return 1
 if __name__ == "__main__":
     _exit(main())

--- a/bin/ldr_logging_test.py
+++ b/bin/ldr_logging_test.py
@@ -74,13 +74,6 @@ def main():
                          dest="log_loc",
                          \
     )
-    parser.add_argument("item", help="Enter a noid for an accession or a " + \
-                        "directory path that you need to validate against" + \
-                        " a type of controlled collection"
-    )
-    parser.add_argument("root",help="Enter the root of the directory path",
-                        action="store"
-    )
     args = parser.parse_args()
 
     ### Begin argument post processing, if required ###
@@ -119,9 +112,11 @@ def main():
     try:
         logger.info("BEGINS")
         ### Begin module code ###
-        b = Batch(args.root, args.item)
-        for item in b.find_items(from_directory=True):
-            print(item.get_file_path())
+        logger.debug('Debug Message')
+        logger.info('Info Message')
+        logger.warn('Warn Message')
+        logger.error('Error Message')
+        logger.critical('Critical Message')
             
         logger.info("ENDS: COMPLETE")
         return 0

--- a/bin/module_template.py
+++ b/bin/module_template.py
@@ -23,6 +23,7 @@ from os.path import split,exists
 ### Local package imports begin ###
 from uchicagoldrLogging.loggers import MasterLogger
 from uchicagoldrLogging.handlers import DefaultTermHandler,DebugTermHandler,DefaultFileHandler,DebugFileHandler,DefaultTermHandlerAtLevel,DefaultFileHandlerAtLevel
+from uchicagoldrLogging.filters import UserAndIPFilter
 
 from uchicagoldr.batch import Batch
 from uchicagoldr.item import Item
@@ -42,8 +43,10 @@ def main():
     ### Application specific log instantation begins ###
     global logger
     logger=masterLog.getChild(__name__)
+    f=UserAndIPFilter()
     termHandler=DefaultTermHandler()
     logger.addHandler(termHandler)
+    logger.addFilter(f)
     ### Application specific log instantation ends ###
 
     ### Parser instantiation begins ###
@@ -85,11 +88,11 @@ def main():
 
     ### Begin argument post processing, if required ###
     if args.verbosity and args.verbosity not in ['DEBUG','INFO','WARN','ERROR','CRITICAL']:
-        logger.error("You did not pass a valid argument to the verbosity flag! Valid arguments include: 'DEBUG','INFO','WARN','ERROR', and 'CRITICAL'")
+        logger.critical("You did not pass a valid argument to the verbosity flag! Valid arguments include: 'DEBUG','INFO','WARN','ERROR', and 'CRITICAL'")
         return(1)
     if args.log_loc:
         if not exists(split(args.log_loc)[0]):
-            logger.error("The specified log location does not exist!")
+            logger.critical("The specified log location does not exist!")
             return(1)
     ### End argument post processing ###
 
@@ -123,14 +126,14 @@ def main():
         for item in b.find_items(from_directory=True):
             print(item.get_file_path())
             
+        ### End module code ###
         logger.info("ENDS: COMPLETE")
         return 0
-        ### End module code ###
     except KeyboardInterrupt:
         logger.error("ENDS: Program aborted manually")
         return 131
     except Exception as e:
-        logger.critical("ENDS: Exception ("+e+")")
+        logger.critical("ENDS: Exception ("+str(e)+")")
         return 1
 if __name__ == "__main__":
     _exit(main())

--- a/bin/module_template.py
+++ b/bin/module_template.py
@@ -1,7 +1,7 @@
 
 __author__ = "[name]"
 __copyright__ = "Copyright 2015, The University of Chicago"
-__version__ = ").0.0"
+__version__ = "0.0.0"
 __maintainer__ = "[name]"
 __email__ = "[email]"
 __status__ = "[Prototype/Development/Production/etc]"

--- a/bin/module_template.py
+++ b/bin/module_template.py
@@ -115,7 +115,7 @@ def main():
             logger.removeHandler(fileHandler)
             fileHandler=DebugFileHandler(args.log_loc)
             logger.addHandler(fileHandler)
-    ### End user specific log instantiation
+    ### End user specified log instantiation ###
     try:
         ### Begin module code ###
         b = Batch(args.root, args.item)

--- a/bin/module_template.py
+++ b/bin/module_template.py
@@ -1,7 +1,7 @@
 
 __author__ = "[name]"
 __copyright__ = "Copyright 2015, The University of Chicago"
-__version__ = "1.0.0"
+__version__ = ").0.0"
 __maintainer__ = "[name]"
 __email__ = "[email]"
 __status__ = "[Prototype/Development/Production/etc]"
@@ -10,16 +10,43 @@ __status__ = "[Prototype/Development/Production/etc]"
 [A brief description of the module as a whole]
 """
 
+
+### Default package imports begin ###
 from argparse import ArgumentParser
-from logging import DEBUG, FileHandler, Formatter, getLogger, \
-    INFO, StreamHandler
 from os import _exit
+from os.path import split,exists
+### Default package imports end ###
+
+### Third party package imports begin ###
+### Third party package imports end ###
+
+### Local package imports begin ###
+from uchicagoldrLogging.masterLogger import MasterLogger
+from uchicagoldrLogging.handlers import DefaultTermHandler,DebugTermHandler,DefaultFileHandler,DebugFileHandler,DefaultTermHandlerAtLevel,DefaultFileHandlerAtLevel
 
 from uchicagoldr.batch import Batch
 from uchicagoldr.item import Item
+### Local package imports end ###
+
+
+### Functions begin ###
+### Functions end ###
+
 
 def main():
-    # start of parser boilerplate
+    ### Master log instantiation begins ###
+    global masterLog
+    masterLog=MasterLogger()
+    ### Master log instantiation ends ###
+
+    ### Application specific log instantation begins ###
+    global logger
+    logger=masterLog.getChild('app')
+    termHandler=DefaultTermHandler()
+    logger.addHandler(termHandler)
+    ### Application specific log instantation ends ###
+
+    ### Parser instantiation begins ###
     parser = ArgumentParser(description="[A brief description of the utility]",
                             epilog="Copyright University of Chicago; " + \
                             "written by "+__author__ + \
@@ -31,16 +58,15 @@ def main():
     # -b sets it to INFO so warnings, errors and generic informative statements
     # will be logged
     parser.add_argument( \
-                         '-b','-verbose',help="set verbose logging",
-                         action='store_const',dest='log_level',
-                         const=INFO,default='INFO' \
+                         '-b','--verbosity',help="set logging verbosity (DEBUG,INFO,WARN,ERROR,CRITICAL)",
+                         nargs='?',
+                         const='INFO' \
     )
     # -d is debugging so anything you want to use a debugger gets logged if you
     # use this level
     parser.add_argument( \
                          '-d','--debugging',help="set debugging logging",
-                         action='store_const',dest='log_level',
-                         const=DEBUG,default='INFO' \
+                         action='store_true' \
     )
     # optionally save the log to a file. set a location or use the default constant
     parser.add_argument( \
@@ -56,30 +82,48 @@ def main():
                         action="store"
     )
     args = parser.parse_args()
-    log_format = Formatter( \
-                            "[%(levelname)s] %(asctime)s  " + \
-                            "= %(message)s",
-                            datefmt="%Y-%m-%dT%H:%M:%S" \
-    )
-    global logger
-    logger = getLogger( \
-                        "lib.uchicago.repository.logger" \
-    )
-    ch = StreamHandler()
-    ch.setFormatter(log_format)
-    logger.setLevel(args.log_level)
+
+    ### Begin argument post processing, if required ###
+    if args.verbosity and args.verbosity not in ['DEBUG','INFO','WARN','ERROR','CRITICAL']:
+        logger.error("You did not pass a valid argument to the verbosity flag! Valid arguments include: 'DEBUG','INFO','WARN','ERROR', and 'CRITICAL'")
+        return(1)
     if args.log_loc:
-        fh = FileHandler(args.log_loc)
-        fh.setFormatter(log_format)
-        logger.addHandler(fh)
-    logger.addHandler(ch)
-    #BEGIN MAIN HERE - EXAMPLE BELOW
+        if not exists(split(args.log_loc)[0]):
+            logger.error("The specified log location does not exist!")
+            return(1)
+    ### End argument post processing ###
+
+    ### Begin user specified log instantiation, if required ###
+    if args.log_loc:
+        fileHandler=DefaultFileHandler(args.log_loc)
+        logger.addHandler(fileHandler)
+
+    if args.verbosity:
+        logger.removeHandler(termHandler)
+        termHandler=DefaultTermHandlerAtLevel(args.verbosity)
+        logger.addHandler(termHandler)
+        if args.log_loc:
+            logger.removeHandler(fileHandler)
+            fileHandler=DefaultFileHandlerAtLevel(args.log_loc,args.verbosity)
+            logger.addHandler(fileHandler)
+
+    if args.debugging:
+        logger.removeHandler(termHandler)
+        termHandler=DebugTermHandler()
+        logger.addHandler(termHandler)
+        if args.log_loc:
+            logger.removeHandler(fileHandler)
+            fileHandler=DebugFileHandler(args.log_loc)
+            logger.addHandler(fileHandler)
+    ### End user specific log instantiation
     try:
+        ### Begin module code ###
         b = Batch(args.root, args.item)
         for item in b.find_items(from_directory=True):
-            print(item.filepath)
+            print(item.get_file_path())
             
         return 0
+        ### End module code ###
     except KeyboardInterrupt:
         logger.error("Program aborted manually")
         return 131

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version = '1.0.0',
     author = "Tyler Danstrom,Brian Balsamo",
     author_email = "tdanstrom@uchicago.edu,balsamo@uchicago.edu",
-    packages = ['uchicagoldr'],
+    packages = ['uchicagoldr','uchicagoldrLogging'],#,'uchicagoldrLogging.masterLogger','uchicagolrdLogger.handlers','uchicagoldrLogging.formatters','uchicagoldr.doesntexist'],
     description = """\
     A set of base classes for interacting with University of Chicago library 
     digital repository objects

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version = '1.0.0',
     author = "Tyler Danstrom,Brian Balsamo",
     author_email = "tdanstrom@uchicago.edu,balsamo@uchicago.edu",
-    packages = ['uchicagoldr','uchicagoldrLogging'],#,'uchicagoldrLogging.masterLogger','uchicagolrdLogger.handlers','uchicagoldrLogging.formatters','uchicagoldr.doesntexist'],
+    packages = ['uchicagoldr','uchicagoldrLogging'],
     description = """\
     A set of base classes for interacting with University of Chicago library 
     digital repository objects

--- a/uchicagoldrLogging/filters.py
+++ b/uchicagoldrLogging/filters.py
@@ -1,0 +1,8 @@
+import logging
+from uchicagoldrLogging.lib import getUserName,getUserIP
+
+class UserAndIPFilter(logging.Filter):
+    def filter(self,record):
+        record.user=getUserName()
+        record.ip=getUserIP()
+        return True

--- a/uchicagoldrLogging/filters.py
+++ b/uchicagoldrLogging/filters.py
@@ -4,5 +4,10 @@ from uchicagoldrLogging.lib import getUserName,getUserIP
 class UserAndIPFilter(logging.Filter):
     def filter(self,record):
         record.user=getUserName()
-        record.ip=getUserIP()
+        record.reportedip=getUserIP()
+        return True
+
+class ManualIPFilter(logging.Filter):
+    def filter(self,record,ip):
+        record.manualip=ip
         return True

--- a/uchicagoldrLogging/formatters.py
+++ b/uchicagoldrLogging/formatters.py
@@ -1,0 +1,3 @@
+def default():
+    from logging import Formatter
+    return Formatter("[%(levelname)s %(asctime)s = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S") 

--- a/uchicagoldrLogging/formatters.py
+++ b/uchicagoldrLogging/formatters.py
@@ -1,3 +1,3 @@
 def default():
     from logging import Formatter
-    return Formatter("[%(levelname)s %(asctime)s = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S") 
+    return Formatter("[%(levelname)s] %(asctime)s = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S") 

--- a/uchicagoldrLogging/formatters.py
+++ b/uchicagoldrLogging/formatters.py
@@ -7,3 +7,7 @@ def verbose():
 def default():
     from logging import Formatter
     return Formatter("[%(levelname)8s] [%(asctime)s] = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S") 
+
+def server():
+    from logging import Formatter
+    return Formatter("[%(levelname)8s] [%(asctime)s] [%(reportedip)15s] [%(manualip)15s] [%(user)s] [%(process)d] [%(filename)s] [%(name)s] [%(relativeCreated)d] = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S")

--- a/uchicagoldrLogging/formatters.py
+++ b/uchicagoldrLogging/formatters.py
@@ -1,3 +1,9 @@
 def default():
     from logging import Formatter
-    return Formatter("[%(levelname)s] %(asctime)s = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S") 
+    from getpass import getuser
+
+    return Formatter("[%(levelname)s] [%(asctime)s] [%(filename)s] ["+getuser()+"] = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S") 
+
+def sparse():
+    from logging import Formatter
+    return Formatter("[%(levelname)s] [%(asctime)s] = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S") 

--- a/uchicagoldrLogging/formatters.py
+++ b/uchicagoldrLogging/formatters.py
@@ -1,9 +1,9 @@
-def default():
+def verbose():
     from logging import Formatter
     from getpass import getuser
 
-    return Formatter("[%(levelname)s] [%(asctime)s] [%(filename)s] ["+getuser()+"] = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S") 
+    return Formatter("[%(levelname)s] [%(asctime)s] [%(filename)s] [%(name)s] ["+getuser()+"] = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S") 
 
-def sparse():
+def default():
     from logging import Formatter
-    return Formatter("[%(levelname)s] [%(asctime)s] = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S") 
+    return Formatter("[%(levelname)8s] [%(asctime)s] = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S") 

--- a/uchicagoldrLogging/handlers.py
+++ b/uchicagoldrLogging/handlers.py
@@ -1,0 +1,59 @@
+def defaultTerm():
+    from logging import StreamHandler
+
+    from uchicagoldrLogger.formatters import default
+
+    formatter=default()
+    terminalHandler=StreamHandler()
+    terminalHandler.setLevel('WARNING')
+    return terminalHandler
+
+def infoTerm():
+    from logging import StreamHandler
+
+    from uchicagoldrLogger.formatters import default
+
+    formatter=default()
+    terminalHandler=StreamHandler()
+    terminalHandler.setLevel('INFO')
+    return terminalHandler
+
+def debugTerm():
+    from logging import StreamHandler
+
+    from uchicagoldrLogger.formatters import default
+
+    formatter=default()
+    terminalHandler=StreamHandler()
+    terminalHandler.setLevel('DEBUG')
+    return terminalHandler
+
+def defaultFile(path):
+    from logging import FileHandler
+
+    from uchicagoldrLogger.formatters import default
+
+    formatter=default()
+    fileHandler=FileHandler(path)
+    fileHandler.setLevel('WARNING')
+    return fileHandler
+
+def infoFile(path):
+    from logging import FileHandler
+
+    from uchicagoldrLogger.formatters import default
+
+    formatter=default()
+    fileHandler=FileHandler(path)
+    fileHandler.setLevel('INFO')
+    return fileHandler
+
+def debugFile(path):
+    from logging import FileHandler
+
+    from uchicagoldrLogger.formatters import default
+
+    formatter=default()
+    fileHandler=FileHandler(path)
+    fileHandler.setLevel('INFO')
+    return fileHandler

--- a/uchicagoldrLogging/handlers.py
+++ b/uchicagoldrLogging/handlers.py
@@ -1,4 +1,4 @@
-def DefaultTerm():
+def DefaultTermHandler():
     from logging import StreamHandler
 
     from uchicagoldrLogging.formatters import default
@@ -8,7 +8,7 @@ def DefaultTerm():
     terminalHandler.setFormatter(default())
     return terminalHandler
 
-def InfoTerm():
+def InfoTermHandler():
     from logging import StreamHandler
 
     from uchicagoldrLogging.formatters import default
@@ -18,7 +18,7 @@ def InfoTerm():
     terminalHandler.setFormatter(default())
     return terminalHandler
 
-def DebugTerm():
+def DebugTermHandler():
     from logging import StreamHandler
 
     from uchicagoldrLogging.formatters import default
@@ -28,7 +28,19 @@ def DebugTerm():
     terminalHandler.setFormatter(default())
     return terminalHandler
 
-def DefaultFile(path):
+def DefaultTermHandlerAtLevel(level):
+    from logging import StreamHandler
+
+    from uchicagoldrLogging.formatters import default
+    
+    assert(level in ['DEBUG','INFO','WARN','ERROR','CRITICAL'])
+
+    terminalHandler=StreamHandler()
+    terminalHandler.setLevel(level)
+    terminalHandler.setFormatter(default())
+    return terminalHandler
+
+def DefaultFileHandler(path):
     from logging import FileHandler
 
     from uchicagoldrLogging.formatters import default
@@ -38,7 +50,7 @@ def DefaultFile(path):
     fileHandler.setFormatter(default())
     return fileHandler
 
-def InfoFile(path):
+def InfoFileHandler(path):
     from logging import FileHandler
 
     from uchicagoldrLogging.formatters import default
@@ -48,12 +60,24 @@ def InfoFile(path):
     fileHandler.setFormatter(default())
     return fileHandler
 
-def DebugFile(path):
+def DebugFileHandler(path):
     from logging import FileHandler
 
     from uchicagoldrLogging.formatters import default
 
     fileHandler=FileHandler(path)
-    fileHandler.setLevel('INFO')
+    fileHandler.setLevel('DEBUG')
+    fileHandler.setFormatter(default())
+    return fileHandler
+
+def DefaultFileHandlerAtLevel(path,level):
+    from logging import FileHandler
+
+    from uchicagoldrLogging.formatters import default
+
+    assert(level in ['DEBUG','INFO','WARN','ERROR','CRITICAL'])
+
+    fileHandler=FileHandler(path)
+    fileHandler.setLevel(level)
     fileHandler.setFormatter(default())
     return fileHandler

--- a/uchicagoldrLogging/handlers.py
+++ b/uchicagoldrLogging/handlers.py
@@ -1,59 +1,59 @@
-def defaultTerm():
+def DefaultTerm():
     from logging import StreamHandler
 
-    from uchicagoldrLogger.formatters import default
+    from uchicagoldrLogging.formatters import default
 
-    formatter=default()
     terminalHandler=StreamHandler()
     terminalHandler.setLevel('WARNING')
+    terminalHandler.setFormatter(default())
     return terminalHandler
 
-def infoTerm():
+def InfoTerm():
     from logging import StreamHandler
 
-    from uchicagoldrLogger.formatters import default
+    from uchicagoldrLogging.formatters import default
 
-    formatter=default()
     terminalHandler=StreamHandler()
     terminalHandler.setLevel('INFO')
+    terminalHandler.setFormatter(default())
     return terminalHandler
 
-def debugTerm():
+def DebugTerm():
     from logging import StreamHandler
 
-    from uchicagoldrLogger.formatters import default
+    from uchicagoldrLogging.formatters import default
 
-    formatter=default()
     terminalHandler=StreamHandler()
     terminalHandler.setLevel('DEBUG')
+    terminalHandler.setFormatter(default())
     return terminalHandler
 
-def defaultFile(path):
+def DefaultFile(path):
     from logging import FileHandler
 
-    from uchicagoldrLogger.formatters import default
+    from uchicagoldrLogging.formatters import default
 
-    formatter=default()
     fileHandler=FileHandler(path)
     fileHandler.setLevel('WARNING')
+    fileHandler.setFormatter(default())
     return fileHandler
 
-def infoFile(path):
+def InfoFile(path):
     from logging import FileHandler
 
-    from uchicagoldrLogger.formatters import default
+    from uchicagoldrLogging.formatters import default
 
-    formatter=default()
     fileHandler=FileHandler(path)
     fileHandler.setLevel('INFO')
+    fileHandler.setFormatter(default())
     return fileHandler
 
-def debugFile(path):
+def DebugFile(path):
     from logging import FileHandler
 
-    from uchicagoldrLogger.formatters import default
+    from uchicagoldrLogging.formatters import default
 
-    formatter=default()
     fileHandler=FileHandler(path)
     fileHandler.setLevel('INFO')
+    fileHandler.setFormatter(default())
     return fileHandler

--- a/uchicagoldrLogging/lib.py
+++ b/uchicagoldrLogging/lib.py
@@ -1,0 +1,8 @@
+def getUserName():
+    from getpass import getuser
+    return getuser()
+
+def getUserIP():
+    from socket import gethostbyname,gethostname
+    return gethostbyname(gethostname())
+

--- a/uchicagoldrLogging/loggers.py
+++ b/uchicagoldrLogging/loggers.py
@@ -5,7 +5,7 @@ def MasterLogger():
     from uchicagoldrLogging.formatters import verbose 
 
     remoteAddress='localhost'
-    remotePort='notarealport'
+    remotePort='9020'
 
     logger=getLogger('lib.uchicago.repository.logger')
     logger.setLevel('DEBUG')

--- a/uchicagoldrLogging/loggers.py
+++ b/uchicagoldrLogging/loggers.py
@@ -2,12 +2,13 @@ def MasterLogger():
     from logging import Formatter,getLogger
     from logging.handlers import SocketHandler
 
-    remoteAddress=None
-    remotePort=None
+    remoteAddress='localhost'
+    remotePort='notarealport'
 
     logger=getLogger('lib.uchicago.repository.logger')
     logger.setLevel('DEBUG')
 
-#    networkHandler=StreamHandler(remoteAddress,remotePort)
+    networkHandler=SocketHandler(remoteAddress,remotePort)
+    logger.addHandler(networkHandler)
 
     return logger

--- a/uchicagoldrLogging/loggers.py
+++ b/uchicagoldrLogging/loggers.py
@@ -2,6 +2,8 @@ def MasterLogger():
     from logging import Formatter,getLogger
     from logging.handlers import SocketHandler
 
+    from uchicagoldrLogging.formatters import verbose 
+
     remoteAddress='localhost'
     remotePort='notarealport'
 
@@ -10,5 +12,5 @@ def MasterLogger():
 
     networkHandler=SocketHandler(remoteAddress,remotePort)
     logger.addHandler(networkHandler)
-
+    
     return logger

--- a/uchicagoldrLogging/masterLogger.py
+++ b/uchicagoldrLogging/masterLogger.py
@@ -1,0 +1,15 @@
+def masterLogger():
+    from logging import FileHandler,Formatter,getLogger,SocketHandler
+    from logging import StreamHandler #This is a placeholder until the logging server is built
+
+    logFormat=Formatter("[%(levelname)s %(asctime)s = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S") #We won't need this once we switch over to the socket handler, thus the hardcode.
+    terminalHandler=StreamHandler() #ditto as above comment
+
+    remoteAddress=None
+    remotePort=None
+
+    logger=getLogger('lib.uchicago.repository.logger')
+    logger.setLevel('DEBUG')
+
+#    networkHandler=StreamHandler(remoteAddress,remotePort)
+    logger.addHandler(terminalHandler) #To be swapped with above once server is in place

--- a/uchicagoldrLogging/masterLogger.py
+++ b/uchicagoldrLogging/masterLogger.py
@@ -1,9 +1,6 @@
-def masterLogger():
-    from logging import FileHandler,Formatter,getLogger,SocketHandler
-    from logging import StreamHandler #This is a placeholder until the logging server is built
-
-    logFormat=Formatter("[%(levelname)s %(asctime)s = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S") #We won't need this once we switch over to the socket handler, thus the hardcode.
-    terminalHandler=StreamHandler() #ditto as above comment
+def MasterLogger():
+    from logging import Formatter,getLogger
+    from logging.handlers import SocketHandler
 
     remoteAddress=None
     remotePort=None
@@ -12,4 +9,5 @@ def masterLogger():
     logger.setLevel('DEBUG')
 
 #    networkHandler=StreamHandler(remoteAddress,remotePort)
-    logger.addHandler(terminalHandler) #To be swapped with above once server is in place
+
+    return logger

--- a/uchicagoldrLoggingServer/server.py
+++ b/uchicagoldrLoggingServer/server.py
@@ -5,6 +5,7 @@ import socketserver
 import struct
 
 from uchicagoldrLogging.filters import ManualIPFilter
+from uchicagoldrLogging.formatters import server
 
 # https://docs.python.org/3/howto/logging-cookbook.html#sending-and-receiving-logging-events-across-a-network
 
@@ -78,8 +79,18 @@ class LogRecordSocketReceiver(socketserver.ThreadingTCPServer):
             abort = self.abort
 
 def main():
-    logging.basicConfig(
-        format="[%(levelname)8s] [%(asctime)s] [%(reportedip)15s] [%(manualip)15s] [%(user)s] [%(process)d] [%(filename)s] [%(name)s] = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S")
+    handlers=[]
+    f=server()
+    
+    termHandler=logging.StreamHandler()
+    termHandler.setFormatter(f)
+    handlers.append(termHandler)
+    
+    fileHandler=logging.handlers.RotatingFileHandler('/Users/balsamo/LDR_Logs/log.txt',maxBytes=1000000000,backupCount=5)
+    fileHandler.setFormatter(f)
+    handlers.append(fileHandler)
+
+    logging.basicConfig(handlers=handlers)
     tcpserver = LogRecordSocketReceiver()
     print('About to start TCP server...')
     tcpserver.serve_until_stopped()

--- a/uchicagoldrLoggingServer/server.py
+++ b/uchicagoldrLoggingServer/server.py
@@ -1,0 +1,91 @@
+import pickle
+import logging
+import logging.handlers
+import socketserver
+import struct
+
+from uchicagoldrLogging.formatters import verbose
+
+# https://docs.python.org/3/howto/logging-cookbook.html#sending-and-receiving-logging-events-across-a-network
+
+class LogRecordStreamHandler(socketserver.StreamRequestHandler):
+    """Handler for a streaming logging request.
+
+    This basically logs the record using whatever logging policy is
+    configured locally.
+    """
+
+    def handle(self):
+        """
+        Handle multiple requests - each expected to be a 4-byte length,
+        followed by the LogRecord in pickle format. Logs the record
+        according to whatever policy is configured locally.
+        """
+        while True:
+            chunk = self.connection.recv(4)
+            if len(chunk) < 4:
+                break
+            slen = struct.unpack('>L', chunk)[0]
+            chunk = self.connection.recv(slen)
+            while len(chunk) < slen:
+                chunk = chunk + self.connection.recv(slen - len(chunk))
+            obj = self.unPickle(chunk)
+            record = logging.makeLogRecord(obj)
+            self.handleLogRecord(record)
+
+    def unPickle(self, data):
+        return pickle.loads(data)
+
+    def handleLogRecord(self, record):
+        # if a name is specified, we use the named logger rather than the one
+        # implied by the record.
+        if self.server.logname is not None:
+            name = self.server.logname
+        else:
+            name = record.name
+        logger = logging.getLogger(name)
+#        terminalHandler=logging.StreamHandler()
+#        terminalHandler.setLevel('DEBUG')
+#        terminalHandler.setFormatter(verbose())
+#        logger.addHandler(terminalHandler)
+        # N.B. EVERY record gets logged. This is because Logger.handle
+        # is normally called AFTER logger-level filtering. If you want
+        # to do filtering, do it at the client end to save wasting
+        # cycles and network bandwidth!
+        logger.handle(record)
+
+class LogRecordSocketReceiver(socketserver.ThreadingTCPServer):
+    """
+    Simple TCP socket-based logging receiver suitable for testing.
+    """
+
+    allow_reuse_address = True
+
+    def __init__(self, host='localhost',
+                 port=logging.handlers.DEFAULT_TCP_LOGGING_PORT,
+                 handler=LogRecordStreamHandler):
+        socketserver.ThreadingTCPServer.__init__(self, (host, port), handler)
+        self.abort = 0
+        self.timeout = 1
+        self.logname = None
+
+    def serve_until_stopped(self):
+        import select
+        abort = 0
+        while not abort:
+            rd, wr, ex = select.select([self.socket.fileno()],
+                                       [], [],
+                                       self.timeout)
+            if rd:
+                self.handle_request()
+            abort = self.abort
+
+def main():
+    logging.basicConfig(
+        format="[%(levelname)8s] [%(asctime)s] [%(ip)15s] [%(user)s] [%(filename)s] [%(name)s] = %(message)s",datefmt="%Y-%m-%dT%H:%M:%S")
+    tcpserver = LogRecordSocketReceiver()
+    print('About to start TCP server...')
+    tcpserver.serve_until_stopped()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Less of a real suggestion to merge the branch (yet) and more a request for comments/creation of a discussion space.

Currently I've updated the logging architecture to (in theory) work as we've discussed. I've run a few tests/stress tests on it and I think I have most of the kinks worked out.

The module template has been updated/generally cleaned up to reflect this. I also wanted to introduce some "required module code" which is to say hooking the module to the master logger, doing some processing over standard options like setting log levels and application log locations, etc. I also think its probably a good idea to log all our application start/ends, so all that business is in there.

Every module now hooks immediately to the master logger, and then generates a child logger for itself to actually write events to. I introduced a few filters (confusingly named, they aren't filtering, they are in fact adding record keys) to keep track of usernames and IPs on the client end. This is all internally reported, so it can only be trusted as far as the local machine is honest and can see. This application specific log is where handlers that do stuff like write to disk for application specific logging purposes go. The master logger (locally) currently only has one handler, a socket handler which is tied to the logging server. (currently this location is hardcoded, I'm beginning to think a corollary to some of this stuff once it gets merged might be to write an over-arching config of some sort.)

On the logging server end there is one more filter, which just lets me write the observed IP address that the data is coming from into the log (in case it differs from the client reported address for whatever reason). The master log on the server side currently has two handlers, a terminal handler and a rotating file handler (5 backups, 1 gig max each). The location for the file handler is currently hardcoded and only relevant to my machine, but easily changed.
